### PR TITLE
feat: scaffold client-side site skeleton

### DIFF
--- a/docs/site/assets/css/styles.css
+++ b/docs/site/assets/css/styles.css
@@ -1,0 +1,201 @@
+:root {
+  color-scheme: light;
+  --bg: #0d1017;
+  --bg-muted: #141922;
+  --card-bg: #191f2b;
+  --text: #f5f7ff;
+  --text-muted: #c2c8d6;
+  --accent: #7f5af0;
+  --accent-soft: rgba(127, 90, 240, 0.15);
+  --border: rgba(245, 247, 255, 0.08);
+  --shadow: rgba(5, 6, 15, 0.4);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top left, rgba(127, 90, 240, 0.15), transparent 55%),
+    radial-gradient(circle at top right, rgba(45, 212, 191, 0.1), transparent 45%),
+    var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+.container {
+  width: min(960px, 92vw);
+  margin: 0 auto;
+  padding: 0 1rem 4rem;
+}
+
+.site-header,
+.site-footer {
+  padding: 2.5rem 0 2rem;
+}
+
+.site-header h1 {
+  margin: 0;
+  font-size: clamp(2.25rem, 3vw + 1rem, 3.25rem);
+}
+
+.tagline {
+  margin-top: 0.75rem;
+  max-width: 48rem;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 2rem;
+  margin-bottom: 1.75rem;
+  box-shadow: 0 20px 45px -25px var(--shadow);
+}
+
+.card h2,
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 0.65rem;
+}
+
+.section-help {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  margin: 0 0 1.2rem;
+}
+
+.file-input {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.9rem 1.6rem;
+  font-weight: 600;
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--accent), #5f6bf0);
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 200ms ease;
+  box-shadow: 0 12px 24px -15px rgba(127, 90, 240, 0.7);
+}
+
+.file-input:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 35px -18px rgba(127, 90, 240, 0.85);
+}
+
+.file-input input[type="file"] {
+  display: none;
+}
+
+.mapping-grid {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 16px;
+  border: 1px dashed rgba(245, 247, 255, 0.2);
+  background: var(--accent-soft);
+}
+
+.mapping-grid__content {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.mapping-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+}
+
+.mapping-field select {
+  appearance: none;
+  padding: 0.6rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(245, 247, 255, 0.2);
+  background: rgba(12, 14, 24, 0.65);
+  color: var(--text);
+  font-size: 0.95rem;
+}
+
+.mapping-field select:focus {
+  outline: 2px solid rgba(127, 90, 240, 0.45);
+  outline-offset: 1px;
+}
+
+.summary-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.summary-metrics .metric-card {
+  padding: 1.2rem 1.4rem;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: rgba(12, 14, 24, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.summary-metrics .metric-card span {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+}
+
+.summary-metrics .metric-card strong {
+  font-size: 1.5rem;
+}
+
+.placeholder {
+  margin: 0;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.charts-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.chart {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: rgba(10, 12, 20, 0.55);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.chart__canvas {
+  min-height: 220px;
+  border-radius: 12px;
+  background: rgba(12, 14, 24, 0.75);
+  border: 1px solid rgba(245, 247, 255, 0.08);
+}
+
+.site-footer p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 680px) {
+  .card {
+    padding: 1.6rem;
+  }
+
+  .charts-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/docs/site/assets/js/app.js
+++ b/docs/site/assets/js/app.js
@@ -1,0 +1,97 @@
+const mappingFields = [
+  { id: "timestamp", label: "Play timestamp" },
+  { id: "track", label: "Track title" },
+  { id: "artist", label: "Artist" },
+  { id: "album", label: "Album" },
+  { id: "duration_ms", label: "Duration (ms)" },
+  { id: "valence", label: "Valence" },
+  { id: "energy", label: "Energy" },
+  { id: "danceability", label: "Danceability" },
+];
+
+const state = {
+  file: null,
+};
+
+function setupMappingGrid(columns) {
+  const mappingGrid = document.getElementById("mapping-grid");
+  const content = document.getElementById("mapping-grid-content");
+  if (!mappingGrid || !content) return;
+
+  content.innerHTML = "";
+
+  mappingFields.forEach((field) => {
+    const wrapper = document.createElement("label");
+    wrapper.className = "mapping-field";
+
+    const name = document.createElement("span");
+    name.textContent = field.label;
+
+    const select = document.createElement("select");
+    select.name = field.id;
+
+    const placeholderOption = document.createElement("option");
+    placeholderOption.value = "";
+    placeholderOption.textContent = "Select column";
+    select.appendChild(placeholderOption);
+
+    columns.forEach((column) => {
+      const option = document.createElement("option");
+      option.value = column;
+      option.textContent = column;
+      select.appendChild(option);
+    });
+
+    wrapper.appendChild(name);
+    wrapper.appendChild(select);
+    content.appendChild(wrapper);
+  });
+
+  mappingGrid.hidden = false;
+}
+
+function showSummaryPlaceholder(filename) {
+  const summarySection = document.getElementById("summary-section");
+  const summaryMetrics = document.getElementById("summary-metrics");
+  if (!summarySection || !summaryMetrics) return;
+
+  summarySection.hidden = false;
+  summaryMetrics.innerHTML = `
+    <p class="placeholder">
+      Parsing <strong>${filename}</strong>… detailed metrics will populate here once Sprint B3 adds the data transforms.
+    </p>
+  `;
+}
+
+function showChartsPlaceholder() {
+  const chartsSection = document.getElementById("charts-section");
+  if (!chartsSection) return;
+  chartsSection.hidden = false;
+}
+
+function handleFileChange(event) {
+  const [file] = event.target.files || [];
+  if (!file) {
+    return;
+  }
+
+  state.file = file;
+
+  // Papaparse will be wired in Sprint B2/B3. For now, mock column detection.
+  setupMappingGrid(["timestamp", "track", "artist", "album", "duration_ms"]);
+  showSummaryPlaceholder(file.name);
+  showChartsPlaceholder();
+}
+
+function initialize() {
+  const csvInput = document.getElementById("csv-input");
+  if (!csvInput) return;
+
+  csvInput.addEventListener("change", handleFileChange);
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initialize);
+} else {
+  initialize();
+}

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Orpheus Client</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./assets/css/styles.css" />
+    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/simple-statistics@7.8.3/dist/simple-statistics.min.js" defer></script>
+    <script src="./assets/js/app.js" type="module" defer></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container">
+        <h1>Project Orpheus</h1>
+        <p class="tagline">
+          Client-side audio journal explorer. Upload a CSV, map your columns, and explore the insights directly in the browser.
+        </p>
+      </div>
+    </header>
+    <main class="container">
+      <section class="card" id="upload-section">
+        <h2>1. Upload your CSV</h2>
+        <p class="section-help">
+          Choose a CSV exported from Spotify, Last.fm, or similar services. We’ll parse and process it directly in your browser.
+        </p>
+        <label class="file-input">
+          <span>Select CSV file</span>
+          <input type="file" id="csv-input" accept=".csv,text/csv" />
+        </label>
+        <div class="mapping-grid" id="mapping-grid" hidden>
+          <h3>Map columns</h3>
+          <p class="section-help">
+            Match your CSV columns to the fields Orpheus understands. More detailed controls will arrive in a later sprint.
+          </p>
+          <div class="mapping-grid__content" id="mapping-grid-content"></div>
+        </div>
+      </section>
+
+      <section class="card" id="summary-section" hidden>
+        <h2>2. Dataset summary</h2>
+        <div class="summary-metrics" id="summary-metrics">
+          <p class="placeholder">Summary metrics will appear here once parsing is complete.</p>
+        </div>
+      </section>
+
+      <section class="card" id="charts-section" hidden>
+        <h2>3. Visualizations</h2>
+        <div class="charts-grid">
+          <div class="chart" id="timeline-chart">
+            <h3>Timeline</h3>
+            <div class="chart__canvas" id="timeline-chart-canvas"></div>
+          </div>
+          <div class="chart" id="radar-chart">
+            <h3>Audio feature radar</h3>
+            <div class="chart__canvas" id="radar-chart-canvas"></div>
+          </div>
+          <div class="chart" id="top-artists-chart">
+            <h3>Top artists</h3>
+            <div class="chart__canvas" id="top-artists-chart-canvas"></div>
+          </div>
+        </div>
+        <p class="section-help">
+          Interactive charts will be wired in future sprints. For now, these containers establish the layout and styling.
+        </p>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>
+          Built as part of the Project Orpheus client-side port. All processing happens locally in your browser.
+        </p>
+      </div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add an initial docs/site/index.html scaffold with upload, summary, and chart sections
- style the client surface with a dedicated styles.css tuned for the new layout
- stub an app.js module that prepares placeholder interactions for future parsing work

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4260fec1c8323a0de989fb489d0e6